### PR TITLE
fix: remove org from openai constructor

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,6 @@ export default function PlayEngine() {
       console.log('key', key);
     }
     openai = new OpenAI({
-      organization: 'openai-internal',
       apiKey: key,
       dangerouslyAllowBrowser: true,
     })


### PR DESCRIPTION
this currently locks out all api keys that aren't from the `openai-internal` org 